### PR TITLE
Add command-line option to disable suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a `--no-suggestions` option, which allows users to disable the generation of spelling suggestions when errors are detected.
+
 ## [3.0.3] - 2017-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Run Spellchecker CLI using the command `spellchecker`. This command takes the fo
                                          repeated-words syntax-mentions syntax-urls". The following plugins are
                                          supported: spell, indefinite-article, repeated-words, syntax-mentions,
                                          syntax-urls.
+--no-suggestions                         Do not print suggested replacements for misspelled words. This option will
+                                         improve Spellchecker's runtime when many errors are detected.
 -q, --quiet                              Do not output anything for files that contain no spelling mistakes.
 -h, --help                               Print this help screen.
 ```

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const { toDictionary } = require('./lib/to-dictionary');
     personalDictionaryPath,
     generateDictionary,
     ignoreRegexes,
+    suggestions,
     plugins,
     quiet,
   } = parseArgs();
@@ -28,6 +29,7 @@ const { toDictionary } = require('./lib/to-dictionary');
     language,
     personalDictionary,
     ignoreRegexes,
+    suggestions,
     plugins,
   });
 

--- a/lib/command-line.js
+++ b/lib/command-line.js
@@ -87,6 +87,11 @@ const optionList = [
     defaultValue: defaultPlugins,
   },
   {
+    name: 'no-suggestions',
+    type: Boolean,
+    description: 'Do not print suggested replacements for misspelled words. This option will improve Spellchecker\'s runtime when many errors are detected.',
+  },
+  {
     name: 'quiet',
     alias: 'q',
     type: Boolean,
@@ -134,6 +139,7 @@ exports.parseArgs = () => {
     help,
   } = parsedArgs;
   const generateDictionary = parsedArgs['generate-dictionary'];
+  const suggestions = !parsedArgs['no-suggestions'];
 
   if (help) {
     console.log(usage);
@@ -167,6 +173,7 @@ exports.parseArgs = () => {
     personalDictionaryPath,
     generateDictionary,
     ignoreRegexes,
+    suggestions,
     plugins,
     quiet,
   };

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -14,7 +14,12 @@ const vfile = require('vfile');
 
 const { isMarkdownFile } = require('./is-markdown-file');
 
-function buildSpellchecker({ dictionary, personalDictionary, plugins }) {
+function buildSpellchecker({
+  dictionary,
+  personalDictionary,
+  suggestions,
+  plugins,
+}) {
   const spellchecker = retext();
 
   if (plugins.includes('indefinite-article')) {
@@ -37,7 +42,7 @@ function buildSpellchecker({ dictionary, personalDictionary, plugins }) {
     spellchecker.use(spell, {
       dictionary,
       personal: personalDictionary,
-      max: Infinity,
+      max: suggestions ? Infinity : -1,
     });
   }
 
@@ -49,11 +54,17 @@ class Spellchecker {
     language,
     personalDictionary,
     ignoreRegexes,
+    suggestions,
     plugins,
   }) {
     // eslint-disable-next-line global-require,import/no-dynamic-require
     const dictionary = require(`dictionary-${language.toLowerCase()}`);
-    this.spellchecker = buildSpellchecker({ dictionary, personalDictionary, plugins });
+    this.spellchecker = buildSpellchecker({
+      dictionary,
+      personalDictionary,
+      suggestions,
+      plugins,
+    });
     this.markdownSpellchecker = remark().use(gemoji).use(remarkRetext, this.spellchecker);
     this.ignoreRegexes = ignoreRegexes;
   }

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -285,4 +285,17 @@ parallel('Spellchecker CLI', function testSpellcheckerCLI() {
     result.stdout.should.not.include('Too many misspellings');
     result.stdout.should.include('no issues found');
   });
+
+  it('enables suggestions by default', async () => {
+    const { code, stdout } = await runWithArguments('test/fixtures/incorrect.txt');
+    code.should.equal(1);
+    stdout.should.include('`preprocessed` is misspelt; did you mean `reprocessed`?');
+  });
+
+  it('allows suggestions to be disabled', async () => {
+    const { code, stdout } = await runWithArguments('test/fixtures/incorrect.txt --no-suggestions');
+    code.should.equal(1);
+    stdout.should.include('`preprocessed` is misspelt');
+    stdout.should.not.include('`preprocessed` is misspelt; did you mean `reprocessed`?');
+  });
 });


### PR DESCRIPTION
It can take `retext-spell` a lot of time to generate spelling suggestions if the given list of files contains a lot of mistakes. This PR adds a command-line flag that allows suggestion generation to be disabled, to improve runtime in these situations.