### PR TITLE
Add the repository to the package.json so it is accessible via the NPM registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   },
   "author": "Thomas Broadley <buriedunderbooks@hotmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:tbroadley/spellchecker-cli.git"
+  },
   "dependencies": {
     "chalk": "^2.3.0",
     "command-line-args": "^4.0.7",


### PR DESCRIPTION
The repo was difficult to find; I had to go through the Travis link to find my way to it. NPM should be warning of this information being missing, so hopefully this sufficiently fixes the omission.