### PR TITLE
Add CLI option to ignore gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.1.1] - 2020-03-15
 
+### Added
+
+- Added flag to allow spellchecking of files that are ignored by git.
+
 ### Fixed
 
 - Upgraded packages that contained security vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [4.1.1] - 2020-03-15
-
 ### Added
 
 - Added flag to allow spellchecking of files that are ignored by git.
+
+## [4.1.1] - 2020-03-15
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Run Spellchecker CLI using the command `spellchecker`. This command takes the fo
 -d, --dictionaries <file> <file>...      Files to combine into a personal dictionary.
 --generate-dictionary                    Write a personal dictionary that contains all found misspellings to
                                          dictionary.txt.
+--no-gitignore                           Don't respect ignore files (.gitignore, .ignore, etc.).
 -i, --ignore <regex> <regex>...          Spelling mistakes that match any of these regexes (after being wrapped with ^
                                          and $) will be ignored.
 -p, --plugins <name> <name>...           A list of retext plugins to use. The default is "spell indefinite-article
@@ -118,6 +119,10 @@ spellchecker --files README.md --ignore "ize"
 ```
 
 In this case, only the literal word "ize" will be ignored, not words that contain it, like "optimize". To match optimize, you could use the regular expression `[A-Za-z]+ize`.
+
+### Gitignore integration
+
+By default `spellchecker-cli` does not spell-check files that are ignored by `.gitignore` files. This decreases the amount of files that need to be processed overall, but occasionally this is desired behavior. To disable this behavior, include the `--no-ignore` flag.
 
 ## Markdown
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ In this case, only the literal word "ize" will be ignored, not words that contai
 
 ### Gitignore integration
 
-By default `spellchecker-cli` does not spell-check files that are ignored by `.gitignore` files. This decreases the amount of files that need to be processed overall, but occasionally this is desired behavior. To disable this behavior, include the `--no-ignore` flag.
+By default `spellchecker-cli` does not spell-check files that are ignored by `.gitignore` files. This decreases the amount of files that need to be processed overall, but occasionally this is undesired. To disable this behavior, include the `--no-ignore` flag.
 
 ## Markdown
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -15,3 +15,4 @@ retext
 Gitlab
 JSON
 JUnit
+Gitignore

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const { generateReports } = require('./lib/report-generator');
     language,
     personalDictionaryPaths,
     generateDictionary,
+    noGitignore,
     ignoreRegexes,
     suggestions,
     plugins,
@@ -38,7 +39,7 @@ const { generateReports } = require('./lib/report-generator');
     files.push(...personalDictionaryPaths.map(filePath => `!${filePath}`));
   }
 
-  const filesFromGlobs = await glob(files, { gitignore: true });
+  const filesFromGlobs = await glob(files, { gitignore: !noGitignore });
 
   console.log();
   console.log(`Spellchecking ${filesFromGlobs.length} file${filesFromGlobs.length === 1 ? '' : 's'}...`);

--- a/lib/command-line.js
+++ b/lib/command-line.js
@@ -74,6 +74,12 @@ const optionList = [
     description: 'Write a personal dictionary that contains all found misspellings to dictionary.txt.',
   },
   {
+    name: 'no-gitignore',
+    type: Boolean,
+    description: "Don't respect ignore files (.gitignore, .ignore, etc.).",
+    defaultValue: false,
+  },
+  {
     name: 'ignore',
     alias: 'i',
     typeLabel: '<regex> <regex>...',
@@ -157,6 +163,7 @@ exports.parseArgs = () => {
     help,
   } = parsedArgs;
   const generateDictionary = parsedArgs['generate-dictionary'];
+  const noGitignore = parsedArgs['no-gitignore'];
   const suggestions = !parsedArgs['no-suggestions'];
   const frontmatterKeys = parsedArgs['frontmatter-keys'];
 
@@ -200,6 +207,7 @@ exports.parseArgs = () => {
     language,
     personalDictionaryPaths,
     generateDictionary,
+    noGitignore,
     ignoreRegexes,
     suggestions,
     plugins,

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -375,4 +375,21 @@ parallel('Spellchecker CLI', function testSpellcheckerCLI() {
     const result = await runWithArguments('test/fixtures/emoji.txt');
     result.should.not.have.property('code');
   });
+
+  it('exits with an error when run on a file that is included in the .gitignore and the --no-gitignore flag is passed', async () => {
+    const createFileResult = await runCommand('echo "This file contians a misspelled word." > test/fixtures/gitignored-file.txt');
+    createFileResult.should.not.have.property('code');
+
+    const { code, stdout } = await runWithArguments('--no-gitignore --files test/fixtures/gitignored-file.txt');
+    code.should.equal(1);
+    stdout.should.include('`contians` is misspelt');
+  });
+
+  it('exits with no error when run on a file that is included in the .gitignore', async () => {
+    const createFileResult = await runCommand('echo "This file contians a misspelled word." > test/fixtures/gitignored-file.txt');
+    createFileResult.should.not.have.property('code');
+
+    const result = await runWithArguments('--files test/fixtures/gitignored-file.txt');
+    result.should.not.have.property('code');
+  });
 });

--- a/test/fixtures/.gitignore
+++ b/test/fixtures/.gitignore
@@ -1,0 +1,1 @@
+gitignored-file.txt


### PR DESCRIPTION
### Description
Add new CLI option as a boolean flag that will disable using the `.gitignore` file to
filter out files from spellchecking

### Motivation
I'm interested in using `spellchecker-cli` on artifacts produced by my build process,
however the hardcoded `{ gitignore: true }` prevents that.

### Testing
Manual testing in the `spellchecker-cli` repo, I ran:
```
node index.js -- --no-gitignore -f node_modules/xtend/LICENCE
```

### Related
 - This PR closes #58 