### PR TITLE
Add spellchecker-disable/spellchecker-enable inline comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added support for inline HTML comments `spellchecker-enable/spellchecker-disable` to exclude blocks from spellchecking (@xoxys).
+
 ## [4.3.0] - 2020-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ In this case, only the literal word "ize" will be ignored, not words that contai
 
 By default `spellchecker-cli` does not spell-check files that are ignored by `.gitignore` files. This decreases the amount of files that need to be processed overall, but occasionally this is undesired. To disable this behavior, include the `--no-ignore` flag.
 
+### Exclude blocks
+
+If you want to exclude whole blocks in a file from spellchecking, this could be achieved by using the HTML inline comments `<!-- spellchecker-disable -->` and `<!-- spellchecker-enable -->`. Everything between these comments will be removed before proceeding with the spellcheck.
+
 ## Markdown
 
 Spellchecker CLI performs some preprocessing on Markdown files (_i.e._ files with the extension `.md` or `.markdown`, ignoring capitalization):

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -89,8 +89,11 @@ class Spellchecker {
       ? this.markdownSpellchecker
       : this.spellchecker;
 
+    const excludeBlockRe = /(<!--\s*spellchecker-disable\s*-->([\S\s]*?)<!-\s*spellchecker-enable\s*-->)/ig;
+
     const contents = (await fs.readFile(filePath)).toString();
-    const contentsWithoutVariationSelectors = contents.replace(/[\uFE0E\uFE0F]/g, '');
+    const contentsWithoutExcludes = contents.replace(excludeBlockRe, '');
+    const contentsWithoutVariationSelectors = contentsWithoutExcludes.replace(/[\uFE0E\uFE0F]/g, '');
 
     const file = vfile({
       contents: contentsWithoutVariationSelectors,
@@ -101,7 +104,7 @@ class Spellchecker {
       messages: result.messages.filter(({ actual }) => {
         const doesNotMatch = regex => !regex.test(actual);
         return every(this.ignoreRegexes, doesNotMatch)
-            && every(this.personalDictionary, doesNotMatch);
+          && every(this.personalDictionary, doesNotMatch);
       }),
     });
   }

--- a/lib/spellchecker.js
+++ b/lib/spellchecker.js
@@ -89,7 +89,7 @@ class Spellchecker {
       ? this.markdownSpellchecker
       : this.spellchecker;
 
-    const excludeBlockRe = /(<!--\s*spellchecker-disable\s*-->([\S\s]*?)<!-\s*spellchecker-enable\s*-->)/ig;
+    const excludeBlockRe = /(<!--\s*spellchecker-disable\s*-->([\S\s]*?)<!--\s*spellchecker-enable\s*-->)/ig;
 
     const contents = (await fs.readFile(filePath)).toString();
     const contentsWithoutExcludes = contents.replace(excludeBlockRe, '');

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -418,4 +418,25 @@ parallel('Spellchecker CLI', function testSpellcheckerCLI() {
     const result = await runWithArguments('--files test/fixtures/gitignored-file.txt');
     result.should.not.have.property('code');
   });
+
+  it('ignores spelling mistakes inside exclude comment blocks', async () => {
+    const code = await runWithArguments('test/fixtures/exclude-blocks.md');
+    code.should.not.have.property('code');
+  });
+
+  it('catch spelling mistakes inside incomplete exclude comment blocks', async () => {
+    const { code, stdout } = await runWithArguments('test/fixtures/exclude-blocks-incorrect.md');
+    code.should.equal(1);
+    stdout.should.include('`iinside` is misspelt');
+  });
+
+  it('ignores spelling mistakes inside single-line exclude comments', async () => {
+    const code = await runWithArguments('test/fixtures/exclude-blocks-singleline.md');
+    code.should.not.have.property('code');
+  });
+
+  it('ignores spelling mistakes inside exclude comment blocks with special formatting', async () => {
+    const code = await runWithArguments('test/fixtures/exclude-blocks-formatting.md');
+    code.should.not.have.property('code');
+  });
 });

--- a/test/fixtures/exclude-blocks-formatting.md
+++ b/test/fixtures/exclude-blocks-formatting.md
@@ -1,0 +1,5 @@
+Use HTML inline comments.
+
+<!--spellchecker-disable                              -->
+Typos iinside this comment blocks should be ignored.
+<!--         SPellchecker-ENABLE-->

--- a/test/fixtures/exclude-blocks-incorrect.md
+++ b/test/fixtures/exclude-blocks-incorrect.md
@@ -1,0 +1,4 @@
+Use HTML inline comments.
+
+<!-- spellchecker-disable -->
+Typos iinside this comment blocks should be ignored.

--- a/test/fixtures/exclude-blocks-singleline.md
+++ b/test/fixtures/exclude-blocks-singleline.md
@@ -1,0 +1,3 @@
+Use HTML inline comments.
+
+<!-- spellchecker-disable -->Typos iinside this comment blocks should be ignored.<!-- spellchecker-enable -->

--- a/test/fixtures/exclude-blocks.md
+++ b/test/fixtures/exclude-blocks.md
@@ -1,0 +1,5 @@
+Use HTML inline comments.
+
+<!-- spellchecker-disable -->
+Typos iinside this comment blocks should be ignored.
+<!-- spellchecker-enable -->


### PR DESCRIPTION
Fixes #42.

Add a regex to remove blocks surrounded by `<!-- spellchecker-disable -->` and `<!-- spellchecker-enable -->` before spellchecking.