### PR TITLE
Add support for configuration in `package.json`

### DIFF
--- a/.spellcheckerrc.yml
+++ b/.spellcheckerrc.yml
@@ -1,5 +1,0 @@
-files:
-  - "**/*.md"
-  - "!test/**/*.md"
-dictionaries:
-  - dictionary.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add support for configuration in `package.json` ([@gadhagod](https://github.com/gadhagod)).
+
 ## [4.8.0] - 2021-06-13
 
 - Convert project to TypeScript.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Spellchecker CLI can also read configuration from a JSON or YAML file. By defaul
 
 You can specify any command line option in a config file. Just make sure to use camelcase option names in the config file, _e.g._ `frontmatterKeys` instead of `frontmatter-keys`.
 
+Also, you can specify command line options in your `package.json`. All keys under `spellchecker` in `package.json` are rendered the sayme way as other configuration-from-file methods.
+
 Command line arguments will override any configuration read from a file.
 
 ### Globs

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -8,6 +8,7 @@ import {
   defaultPlugins, getUsage, readArgs, supportedLanguages, supportedPlugins,
 } from './command-line';
 import { readConfigFile } from './file';
+import { readFromPackage } from './package';
 import { InternalConfig } from './types';
 
 const defaultValues = {
@@ -23,7 +24,8 @@ const defaultValues = {
 export const parseConfig = (): InternalConfig => {
   const args = readArgs();
   const configFile = readConfigFile(args.config);
-  const parsedArgs = merge({}, defaultValues, configFile, args);
+  const packageFile = readFromPackage();
+  const parsedArgs = merge({}, defaultValues, packageFile, configFile, args);
 
   const {
     files,

--- a/lib/config/package.ts
+++ b/lib/config/package.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+
+import { printError } from '../print-error';
+
+import { ExternalConfig } from './types';
+
+export function readFromPackage(): ExternalConfig {
+  let config;
+  try {
+    config = JSON.parse(readFileSync('package.json') as unknown as string);
+  } catch (err) {
+    if ((err as Error).name === 'SyntaxError') {
+      printError('Unable to parse package.json');
+    } else {
+      printError(`Unable to parse package.json. Error: ${(err as Error).message}`);
+    }
+  }
+  if ('spellchecker' in config) {
+    return config.spellchecker;
+  }
+  return {};
+}

--- a/package.json
+++ b/package.json
@@ -74,5 +74,14 @@
     "mocha.parallel": "0.15.5",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2"
+  },
+  "spellchecker": {
+    "files": [
+      "**/*.md",
+      "!test/**/*.md"
+    ],
+    "dictionaries": [
+      "dictionary.txt"
+    ]
   }
 }

--- a/test/cli-test.ts
+++ b/test/cli-test.ts
@@ -477,4 +477,8 @@ parallel('Spellchecker CLI', function testSpellcheckerCLI(this: { timeout(n: num
     const result = await runWithArguments('--config test/fixtures/config/basic.jsonc');
     result.should.not.have.property('code');
   });
+  it ('can read options from `package.json`', async () => {
+    const result = await runCommand("node build/index.js");
+    result.should.not.have.property('code');
+  })
 });


### PR DESCRIPTION
As part of submitting a pull request, please:

- Attempt to add tests for your change. If you're having difficulty, feel free to open the PR and ask for help.
- If you're adding or changing a command-line flag, update the flags list in [the Usage section of the README](https://github.com/tbroadley/spellchecker-cli#usage).
- If you're adding a feature or changing behaviour, document the change in the README.
- Add a line to the Unreleased section of CHANGELOG.md describing your change (and crediting yourself if you'd like!)

You can now specify command line arguments from `package.json`.

```json
// pacakge.json
{
  "spellchecker": {
    "files": ["README.md"]
  }
}
```