### PR TITLE
Run only specified plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Fix a bug where the tool wouldn't respect the `--plugins` command line option or the `plugins` key in config files.
+
 ## [4.8.0] - 2021-06-13
 
 - Convert project to TypeScript.

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -1,5 +1,5 @@
+import assign from 'lodash/assign';
 import difference from 'lodash/difference';
-import merge from 'lodash/merge';
 
 import { FrontmatterConfig } from '../frontmatter-filter';
 import { printError } from '../print-error';
@@ -23,7 +23,7 @@ const defaultValues = {
 export const parseConfig = (): InternalConfig => {
   const args = readArgs();
   const configFile = readConfigFile(args.config);
-  const parsedArgs = merge({}, defaultValues, configFile, args);
+  const parsedArgs = assign({}, defaultValues, configFile, args);
 
   const {
     files,

--- a/test/cli-test.ts
+++ b/test/cli-test.ts
@@ -252,6 +252,16 @@ parallel('Spellchecker CLI', function testSpellcheckerCLI(this: { timeout(n: num
     });
   });
 
+  it('doesn\'t apply plugins that aren\'t specified on the command line', async () => {
+    const result = await runWithArguments('--files test/fixtures/repeated-words.md --plugins spell');
+    result.should.not.have.property('code');
+  });
+
+  it('doesn\'t apply plugins that aren\'t specified in a config file', async () => {
+    const result = await runWithArguments('--files test/fixtures/repeated-words.md --config test/fixtures/config/spell-only.yml');
+    result.should.not.have.property('code');
+  });
+
   it('applies retext-indefinite-article when it is specified', async () => {
     const { code, stdout } = await runWithArguments('test/fixtures/indefinite-article.md -p indefinite-article');
     code!.should.equal(1);

--- a/test/cli-test.ts
+++ b/test/cli-test.ts
@@ -215,17 +215,13 @@ parallel('Spellchecker CLI', function testSpellcheckerCLI(this: { timeout(n: num
   it('exits with no error when passed an empty list of plugins', async () => {
     const result = await runWithArguments('--files a b c --plugins');
     result.should.not.have.property('code');
+    result.stdout.should.equal('Spellchecking 0 files...\n');
   });
 
   it('exits with an error when passed unknown plugins', async () => {
     const { code, stderr } = await runWithArguments('--files a b c --plugins d e f');
     code!.should.equal(1);
     stderr.should.include('The following retext plugins are not supported: d, e, f.');
-  });
-
-  it('does nothing when passed an empty list of plugins', async () => {
-    const { stdout } = await runWithArguments('--files a b c --plugins');
-    stdout.should.equal('Spellchecking 0 files...\n');
   });
 
   it('applies all default plugins by default', async () => {

--- a/test/fixtures/config/spell-only.yml
+++ b/test/fixtures/config/spell-only.yml
@@ -1,0 +1,5 @@
+files:
+  - test/fixtures/en-CA.txt
+plugins:
+  - spell
+language: en-CA


### PR DESCRIPTION
Fixes #80 

A user pointed out a bug where, even though they'd specified a specific list of plugins to run, all plugins were still running. The issue was that, when merging configuration from different sources together, we were using Lodash's `merge` function. When merging the default plugins array:

```js
[
  'spell',
  'indefinite-article',
  'repeated-words',
  'syntax-mentions',
  'syntax-urls',
]
```

And the array passed by the user on the command line:

```js
[
  'spell',
  'syntax-urls',
] 
```

Instead of the user's specified plugins completely overriding the defaults, the tool would run with the following plugins:

```js
[
  'spell',
  'syntax-urls',
  'repeated-words',
  'syntax-mentions',
  'syntax-urls',
]
```

This PR fixes the issue by replacing `merge` with `assign`, which doesn't merge arrays in this manner.
