### PR TITLE
feat: Add support for MDX files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add support for MDX files([@davemooreuws](https://github.com/davemooreuws)).
+
 ## [4.8.1] - 2021-10-31
 
 Happy Halloween!

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ By default `spellchecker-cli` does not spell-check files that are ignored by `.g
 
 ### Markdown
 
-Spellchecker CLI performs some preprocessing on Markdown files (_i.e._ files with the extension `.md` or `.markdown`, ignoring capitalization):
+Spellchecker CLI performs some preprocessing on Markdown files (_i.e._ files with the extension `.md`, `.markdown` or `.mdx`, ignoring capitalization):
 
 - Ignores `inline code` and tables
 - Transforms [Gemoji](https://github.com/wooorm/gemoji) into Unicode emoji, so that emoji names like `:octocat:` aren't spellchecked

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -25,3 +25,4 @@ uncapitalized
 config
 camelcase
 JSONC
+MDX

--- a/lib/is-markdown-file.ts
+++ b/lib/is-markdown-file.ts
@@ -1,3 +1,3 @@
 import path from 'path';
 
-export const isMarkdownFile = (filePath: string): boolean => ['.md', '.markdown'].includes(path.extname(filePath).toLowerCase());
+export const isMarkdownFile = (filePath: string): boolean => ['.md', '.markdown', '.mdx'].includes(path.extname(filePath).toLowerCase());

--- a/test/cli-test.ts
+++ b/test/cli-test.ts
@@ -151,6 +151,14 @@ parallel('Spellchecker CLI', function testSpellcheckerCLI(this: { timeout(n: num
     });
   });
 
+  it('handles MDX syntax', async () => {
+    const { code, stdout } = await runWithArguments('--files test/fixtures/markdown.mdx');
+    code!.should.equal(1);
+    ['Spellig', 'paragrap', 'containin', 'mistaks', 'Bullts', 'Moar'].forEach((word) => {
+      stdout.should.include(`\`${word}\` is misspelt`);
+    });
+  });
+
   it('ignores spelling mistakes in code blocks', async () => {
     const result = await runWithArguments('-f test/fixtures/code-blocks.md');
     result.should.not.have.property('code');

--- a/test/fixtures/markdown.mdx
+++ b/test/fixtures/markdown.mdx
@@ -1,0 +1,6 @@
+# Spellig mistake
+
+This is a paragrap containin mistaks.
+
+- Bullts
+- Moar bullets

--- a/test/is-markdown-file-test.ts
+++ b/test/is-markdown-file-test.ts
@@ -13,6 +13,10 @@ describe('isMarkdownFile', () => {
     isMarkdownFile('test.markdown').should.equal(true);
   });
 
+  it('returns true for a file with the extension `.mdx`', () => {
+    isMarkdownFile('test.mdx').should.equal(true);
+  });
+
   it('returns true for a file with the extension `.MD`', () => {
     isMarkdownFile('test.MD').should.equal(true);
   });


### PR DESCRIPTION
Added the mdx extension to markdown checks. 
This is important to ignore code blocks etc in mdx (without renaming the ext).