### PR TITLE
Fall back to reading config from cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you've installed Spellchecker CLI globally, you can simply run `spellchecker`
 
 ### Configuration files
 
-Spellchecker CLI can also read configuration from a JSON or YAML file. By default, it will try to read `.spellcheckerrc.yaml`, `.spellcheckerrc.yml`, `.spellcheckerrc.json`, or `.spellcheckerrc.jsonc` in the root directory of your project (as determined by [`pkg-dir`](https://github.com/sindresorhus/pkg-dir)). You can also specify a different path using the `--config` command line argument.
+Spellchecker CLI can also read configuration from a JSON or YAML file. By default, it will try to read `.spellcheckerrc.yaml`, `.spellcheckerrc.yml`, `.spellcheckerrc.json`, or `.spellcheckerrc.jsonc` in the root directory of your project (as determined by [`pkg-dir`](https://github.com/sindresorhus/pkg-dir)). If `pkg-dir` can't find the project's root directory (e.g. if you've installed Spellchecker CLI globally), it'll look in `process.cwd()` instead. You can also specify a different path using the `--config` command line argument.
 
 You can specify any command line option in a config file. Just make sure to use camelcase option names in the config file, _e.g._ `frontmatterKeys` instead of `frontmatter-keys`.
 

--- a/lib/config/file.ts
+++ b/lib/config/file.ts
@@ -36,7 +36,7 @@ export const readConfigFile = (
     return tryLoad(filePathFromArgs);
   }
 
-  const packageDirectory = packageDirectorySync();
+  const packageDirectory = packageDirectorySync() ?? process.cwd();
 
   const filePath = [
     './.spellcheckerrc.yaml',


### PR DESCRIPTION
After installing the package globally, `packageDirectorySync` may return undefined.