### PR TITLE
Issue 116: Updating the README for `pre-commit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ If you want to use the Spellchecker CLI as part of a [`pre-commit` hook](https:/
 
 ```yaml
 - repo: https://github.com/tbroadley/spellchecker-cli
+  rev: v6.2.0
   hooks:
     - id: spellchecker-cli
       name: spellcheck
+      language_version: 18.19.1
       types: [markdown]
       stages: # optional: if you want to specify stages to run the hook on
         - '' # see https://pre-commit.com/#confining-hooks-to-run-at-certain-stages


### PR DESCRIPTION
Following up on #116 - now that there is a release/tag with the `pre-commit-hooks.yaml`, I believe it should be included in the README!

Also included is a line for recommending the node `language_version` of `18.19.1` (latest, stable for node 18). Could be updated to 20 if you'd like. I added this because my own dev environment got a little wonky and messed up the initial pre-commit setup until this was explicitly called out.